### PR TITLE
Add method to query a translation

### DIFF
--- a/lib/unbabel.rb
+++ b/lib/unbabel.rb
@@ -20,7 +20,7 @@ class Unbabel
     unbabel_endpoint_domain = ENV['UNBABEL_URL'] if ENV['UNBABEL_URL']
     @conn = Faraday.new(:url => unbabel_endpoint_domain) do |faraday|
       faraday.request  :url_encoded
-      faraday.response :logger  
+      faraday.response :logger
       faraday.adapter  Faraday.default_adapter
     end
   end
@@ -48,13 +48,13 @@ class Unbabel
     response
   end
 
-  def post_translations(text, target_language, source_language: nil, type: nil, tone: nil, 
+  def post_translations(text, target_language, source_language: nil, type: nil, tone: nil,
                         visibility: nil, public_url: nil, callback_url: nil, topics: [],
                         instructions: nil, uid: nil, text_format: "text", target_text: nil,
                         origin: nil)
     data = {
-      text: text, 
-      target_language: target_language, 
+      text: text,
+      target_language: target_language,
       source_language: source_language,
       type: type,
       tone: tone,
@@ -70,5 +70,9 @@ class Unbabel
     }
     return api_call('translation/', data: data, method: 'post')
   end
-  
+
+  def query_translation(uid)
+    return api_call("translation/#{uid}/",  method: 'get')
+  end
+
 end


### PR DESCRIPTION
Added method to query a translation's state.
The other changes in the diff are trailing whitespace removal.
