### PR TITLE
Fix json dependency vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     unbabel-ruby (1.0.0)
       faraday (~> 0.15)
-      json (= 2.1)
+      json (>= 2.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -15,13 +15,13 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    faraday (0.15.3)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     hashdiff (0.3.7)
     jaro_winkler (1.5.1)
-    json (2.1.0)
+    json (2.3.1)
     method_source (0.9.0)
-    multipart-post (2.0.0)
+    multipart-post (2.1.1)
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
@@ -71,4 +71,4 @@ DEPENDENCIES
   webmock (~> 3.4)
 
 BUNDLED WITH
-   1.16.5
+   1.17.2

--- a/spec/unbabel-sdk/unbabel_spec.rb
+++ b/spec/unbabel-sdk/unbabel_spec.rb
@@ -11,7 +11,6 @@ describe Unbabel do
       'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
       'Authorization' => "ApiKey #{username}:#{apikey}",
       'Content-Type' => 'application/json',
-      'User-Agent' => 'Faraday v0.15.3'
     }
   end
 

--- a/unbabel-ruby.gemspec
+++ b/unbabel-ruby.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'faraday', '~> 0.15'
-  spec.add_runtime_dependency 'json', '2.1'
+  spec.add_runtime_dependency 'json', '>= 2.3.0'
 
   spec.add_development_dependency 'pry', '~> 0.11'
   spec.add_development_dependency 'rspec', '~> 3.8'


### PR DESCRIPTION
Upgrade json to version to 2.3.0 in order to solve the following vulnerabilities

https://github.com/advisories/GHSA-jphg-qwrw-7w9g